### PR TITLE
Fix unitialized _pendingSessionRequest

### DIFF
--- a/Assets/Scripts/FeedPlayer.cs
+++ b/Assets/Scripts/FeedPlayer.cs
@@ -101,6 +101,10 @@ namespace FeedFM
             InitializeRequiredComponents();
             SetupSession();
             SetupMixingAudioPlayer();
+        }
+
+        private void Start()
+        {
             FetchSession();
         }
 

--- a/Assets/Scripts/Session.cs
+++ b/Assets/Scripts/Session.cs
@@ -153,7 +153,7 @@ namespace FeedFM
         {
             // we haven't started playing any music yet
             startedPlayback = false;
-            _pendingSessionRequest = new PendingRequest();
+            if (_pendingSessionRequest == null) _pendingSessionRequest = new PendingRequest();
             // Assume we have no session
             Available = false;
             LoadClientId();
@@ -173,6 +173,8 @@ namespace FeedFM
             {
                 ajax.addParameter("client_id", _baseClientId);
             }
+
+            if (_pendingSessionRequest == null) _pendingSessionRequest = new PendingRequest();
 
             while (_pendingSessionRequest.retryCount < _maxNumberOfRetries)
             {


### PR DESCRIPTION
FeedPlayer calls FetchSession in Awake() before Awake() of the Session component has run. That's why the _pendingSessionRequest Variable is still uninitialized at this point.

This pull request adds a safety check that initializes the variable if it hasn't been done